### PR TITLE
Added provider genericapi

### DIFF
--- a/provider/genericapi/client.go
+++ b/provider/genericapi/client.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
+)
+
+// DefaultTimeout api requests after 180s
+const DefaultTimeout = 180 * time.Second
+
+// Errors
+var (
+	ErrAPIDown = errors.New("genericapi: the requested endpoint is down")
+)
+
+// APIError error
+type APIError struct {
+	Code    string
+	Message string
+}
+
+func (err *APIError) Error() string {
+	return fmt.Sprintf("Error %s: %q", err.Code, err.Message)
+}
+
+// Logger is the interface that should be implemented for loggers that wish to
+// log HTTP requests and HTTP responses.
+type Logger interface {
+	// LogRequest logs an HTTP request.
+	LogRequest(*http.Request)
+
+	// LogResponse logs an HTTP response.
+	LogResponse(*http.Response)
+}
+
+// Client represents a client to call the GoDaddy API
+type Client struct {
+	// APIKey holds the Application key
+	APIKey string
+
+	// APISecret holds the Application secret key
+	APISecret string
+
+	// API endpoint
+	APIEndPoint string
+
+	// Client is the underlying HTTP client used to run the requests. It may be overloaded but a default one is instanciated in ``NewClient`` by default.
+	Client *http.Client
+
+	// Logger is used to log HTTP requests and responses.
+	Logger Logger
+
+	Timeout time.Duration
+}
+
+// NewClient represents a new client to call the API
+func NewClient(useOTE bool, apiKey, apiSecret string) (*Client, error) {
+	var endpoint string
+
+	if useOTE {
+		endpoint = " https://api.ote-godaddy.com"
+	} else {
+		endpoint = "https://api.godaddy.com"
+	}
+
+	client := Client{
+		APIKey:      apiKey,
+		APISecret:   apiSecret,
+		APIEndPoint: endpoint,
+		Client:      &http.Client{},
+		Timeout:     DefaultTimeout,
+	}
+
+	// Get and check the configuration
+	if err := client.validate(); err != nil {
+		return nil, err
+	}
+	return &client, nil
+}
+
+//
+// Common request wrappers
+//
+
+// Get is a wrapper for the GET method
+func (c *Client) Get(url string, resType interface{}) error {
+	return c.CallAPI("GET", url, nil, resType, true)
+}
+
+// Patch is a wrapper for the POST method
+func (c *Client) Patch(url string, reqBody, resType interface{}) error {
+	return c.CallAPI("PATCH", url, reqBody, resType, true)
+}
+
+// Post is a wrapper for the POST method
+func (c *Client) Post(url string, reqBody, resType interface{}) error {
+	return c.CallAPI("POST", url, reqBody, resType, true)
+}
+
+// Put is a wrapper for the PUT method
+func (c *Client) Put(url string, reqBody, resType interface{}) error {
+	return c.CallAPI("PUT", url, reqBody, resType, true)
+}
+
+// Delete is a wrapper for the DELETE method
+func (c *Client) Delete(url string, resType interface{}) error {
+	return c.CallAPI("DELETE", url, nil, resType, true)
+}
+
+// GetWithContext is a wrapper for the GET method
+func (c *Client) GetWithContext(ctx context.Context, url string, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "GET", url, nil, resType, true)
+}
+
+// PatchWithContext is a wrapper for the POST method
+func (c *Client) PatchWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "PATCH", url, reqBody, resType, true)
+}
+
+// PostWithContext is a wrapper for the POST method
+func (c *Client) PostWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "POST", url, reqBody, resType, true)
+}
+
+// PutWithContext is a wrapper for the PUT method
+func (c *Client) PutWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "PUT", url, reqBody, resType, true)
+}
+
+// DeleteWithContext is a wrapper for the DELETE method
+func (c *Client) DeleteWithContext(ctx context.Context, url string, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "DELETE", url, nil, resType, true)
+}
+
+// NewRequest returns a new HTTP request
+func (c *Client) NewRequest(method, path string, reqBody interface{}, needAuth bool) (*http.Request, error) {
+	var body []byte
+	var err error
+
+	if reqBody != nil {
+		body, err = json.Marshal(reqBody)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	target := fmt.Sprintf("%s%s", c.APIEndPoint, path)
+	req, err := http.NewRequest(method, target, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	// Inject headers
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json;charset=utf-8")
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("sso-key %s:%s", c.APIKey, c.APISecret))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "ExternalDNS/"+externaldns.Version)
+
+	// Send the request with requested timeout
+	c.Client.Timeout = c.Timeout
+
+	return req, nil
+}
+
+// Do sends an HTTP request and returns an HTTP response
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	if c.Logger != nil {
+		c.Logger.LogRequest(req)
+	}
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if c.Logger != nil {
+		c.Logger.LogResponse(resp)
+	}
+	return resp, nil
+}
+
+// CallAPI is the lowest level call helper. If needAuth is true,
+// inject authentication headers and sign the request.
+//
+// Request signature is a sha1 hash on following fields, joined by '+':
+// - applicationSecret (from Client instance)
+// - consumerKey (from Client instance)
+// - capitalized method (from arguments)
+// - full request url, including any query string argument
+// - full serialized request body
+// - server current time (takes time delta into account)
+//
+// Call will automatically assemble the target url from the endpoint
+// configured in the client instance and the path argument. If the reqBody
+// argument is not nil, it will also serialize it as json and inject
+// the required Content-Type header.
+//
+// If everything went fine, unmarshall response into resType and return nil
+// otherwise, return the error
+func (c *Client) CallAPI(method, path string, reqBody, resType interface{}, needAuth bool) error {
+	return c.CallAPIWithContext(context.Background(), method, path, reqBody, resType, needAuth)
+}
+
+// CallAPIWithContext is the lowest level call helper. If needAuth is true,
+// inject authentication headers and sign the request.
+//
+// Request signature is a sha1 hash on following fields, joined by '+':
+// - applicationSecret (from Client instance)
+// - consumerKey (from Client instance)
+// - capitalized method (from arguments)
+// - full request url, including any query string argument
+// - full serialized request body
+// - server current time (takes time delta into account)
+//
+// Context is used by http.Client to handle context cancelation
+//
+// Call will automatically assemble the target url from the endpoint
+// configured in the client instance and the path argument. If the reqBody
+// argument is not nil, it will also serialize it as json and inject
+// the required Content-Type header.
+//
+// If everything went fine, unmarshall response into resType and return nil
+// otherwise, return the error
+func (c *Client) CallAPIWithContext(ctx context.Context, method, path string, reqBody, resType interface{}, needAuth bool) error {
+	req, err := c.NewRequest(method, path, reqBody, needAuth)
+	if err != nil {
+		return err
+	}
+	req = req.WithContext(ctx)
+	response, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	return c.UnmarshalResponse(response, resType)
+}
+
+// UnmarshalResponse checks the response and unmarshals it into the response
+// type if needed Helper function, called from CallAPI
+func (c *Client) UnmarshalResponse(response *http.Response, resType interface{}) error {
+	// Read all the response body
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	// < 200 && >= 300 : API error
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		apiError := &APIError{
+			Code: fmt.Sprintf("HTTPStatus: %d", response.StatusCode),
+		}
+
+		if err = json.Unmarshal(body, apiError); err != nil {
+			return err
+		}
+
+		return apiError
+	}
+
+	// Nothing to unmarshal
+	if len(body) == 0 || resType == nil {
+		return nil
+	}
+
+	return json.Unmarshal(body, &resType)
+}
+
+func (c *Client) validate() error {
+	var response interface{}
+
+	if err := c.Get("/v1/domains?statuses=ACTIVE", response); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/provider/genericapi/genericapi.go
+++ b/provider/genericapi/genericapi.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericapi
+
+import (
+	"context"
+	"errors"
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+)
+
+var (
+	// ErrRecordToMutateNotFound when ApplyChange has to update/delete and didn't found the record in the existing zone (Change with no record ID)
+	ErrRecordToMutateNotFound = errors.New("record to mutate not found in current zone")
+	// ErrNoDryRun No dry run support for the moment
+	ErrNoDryRun = errors.New("dry run not supported")
+)
+
+type httpClient interface {
+	Patch(string, interface{}, interface{}) error
+	Post(string, interface{}, interface{}) error
+	Put(string, interface{}, interface{}) error
+	Get(string, interface{}) error
+	Delete(string, interface{}) error
+}
+
+type GDProvider struct {
+	provider.BaseProvider
+
+	domainFilter endpoint.DomainFilter
+	client       httpClient
+	ttl          int64
+	DryRun       bool
+}
+
+// NewGoDaddyProvider initializes a new GoDaddy DNS based Provider.
+func NewGoDaddyProvider(ctx context.Context, domainFilter endpoint.DomainFilter, ttl int64, apiKey, apiSecret string, useOTE, dryRun bool) (*GDProvider, error) {
+	client, err := NewClient(useOTE, apiKey, apiSecret)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Add Dry Run support
+	if dryRun {
+		return nil, ErrNoDryRun
+	}
+
+	return &GDProvider{
+		client:       client,
+		domainFilter: domainFilter,
+		ttl:          600,
+		DryRun:       dryRun,
+	}, nil
+}
+
+// Records returns the list of records in all relevant zones.
+func (p *GDProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	// TODO: Move to config
+	apiEndpoint := "/v1/regions/test-region/domains"
+
+	//var endpoints []*endpoint.Endpoint
+	endpoints := []*endpoint.Endpoint{}
+
+	if err := p.client.Get(apiEndpoint, &endpoints); err != nil {
+		return nil, err
+	}
+
+	log.Infof("GenericHTTP: %d endpoints have been found", len(endpoints))
+
+	return endpoints, nil
+}
+
+// ApplyChanges applies a given set of changes in a given zone.
+func (p *GDProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+
+
+	// TODO: Move to config
+	apiEndpoint := "/v1/regions/test-region/domains"
+
+	var apiResponse string
+
+	if err := p.client.Post(apiEndpoint, changes, apiResponse); err != nil {
+		log.Error("There was a problem contacting to the API endpoint while trying to update the DNS records")
+	}
+
+	return nil
+}
+
+func maxOf(vars ...int64) int64 {
+	max := vars[0]
+
+	for _, i := range vars {
+		if max < i {
+			max = i
+		}
+	}
+
+	return max
+}

--- a/provider/genericapi/genericapi_test.go
+++ b/provider/genericapi/genericapi_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericapi
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+)
+
+type mockGoDaddyClient struct {
+	mock.Mock
+	currentTest *testing.T
+}
+
+func newMockGoDaddyClient(t *testing.T) *mockGoDaddyClient {
+	return &mockGoDaddyClient{
+		currentTest: t,
+	}
+}
+
+var (
+	zoneNameExampleOrg string = "example.org"
+	zoneNameExampleNet string = "example.net"
+)
+
+func (c *mockGoDaddyClient) Post(endpoint string, input interface{}, output interface{}) error {
+	log.Infof("POST: %s - %v", endpoint, input)
+	stub := c.Called(endpoint, input)
+	data, _ := json.Marshal(stub.Get(0))
+	json.Unmarshal(data, output)
+	return stub.Error(1)
+}
+
+func (c *mockGoDaddyClient) Patch(endpoint string, input interface{}, output interface{}) error {
+	log.Infof("PATCH: %s - %v", endpoint, input)
+	stub := c.Called(endpoint, input)
+	data, _ := json.Marshal(stub.Get(0))
+	json.Unmarshal(data, output)
+	return stub.Error(1)
+}
+
+func (c *mockGoDaddyClient) Put(endpoint string, input interface{}, output interface{}) error {
+	log.Infof("PUT: %s - %v", endpoint, input)
+	stub := c.Called(endpoint, input)
+	data, _ := json.Marshal(stub.Get(0))
+	json.Unmarshal(data, output)
+	return stub.Error(1)
+}
+
+func (c *mockGoDaddyClient) Get(endpoint string, output interface{}) error {
+	log.Infof("GET: %s", endpoint)
+	stub := c.Called(endpoint)
+	data, _ := json.Marshal(stub.Get(0))
+	json.Unmarshal(data, output)
+	return stub.Error(1)
+}
+
+func (c *mockGoDaddyClient) Delete(endpoint string, output interface{}) error {
+	log.Infof("DELETE: %s", endpoint)
+	stub := c.Called(endpoint)
+	data, _ := json.Marshal(stub.Get(0))
+	json.Unmarshal(data, output)
+	return stub.Error(1)
+}
+
+func TestGoDaddyRecords(t *testing.T) {
+	assert := assert.New(t)
+	client := newMockGoDaddyClient(t)
+	provider := &GDProvider{
+		client: client,
+	}
+
+	client.On("Get", "/v1/regions/test-region/domains").Return([]endpoint.Endpoint{
+		{
+			DNSName: "agent",
+			Targets: endpoint.Targets{"192.168.0.138", "192.168.1.138"},
+			RecordType: "A",
+			SetIdentifier: "agent.test-region.cratedb.net",
+			RecordTTL: endpoint.TTL(100),
+		},
+	}, nil).Once()
+
+	endpoints, err := provider.Records(context.TODO())
+	assert.NoError(err)
+
+	// Little fix for multi targets endpoint
+	for _, endpoint := range endpoints {
+		sort.Strings(endpoint.Targets)
+	}
+
+	assert.ElementsMatch(endpoints, []*endpoint.Endpoint{
+		{
+			DNSName:    "agent",
+			Targets: []string{
+				"192.168.0.138",
+				"192.168.1.138",
+			},
+			RecordType: "A",
+			SetIdentifier: "agent.test-region.cratedb.net",
+			RecordTTL:  100,
+		},
+	})
+
+	client.AssertExpectations(t)
+}
+
+func TestGoDaddyChange(t *testing.T) {
+	assert := assert.New(t)
+	client := newMockGoDaddyClient(t)
+	provider := &GDProvider{
+		client: client,
+	}
+
+	changes := plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{
+				DNSName: "to-be-created",
+				Targets: []string{"192.168.0.138", "192.168.1.138"},
+				RecordType: "A",
+				SetIdentifier: "to-be-created.test-region.cratedb.net",
+				RecordTTL: endpoint.TTL(100),
+			},
+		},
+		Delete: []*endpoint.Endpoint{
+			{
+				DNSName: "to-be-deleted",
+				Targets: []string{"192.168.0.138", "192.168.1.138"},
+				RecordType: "A",
+				SetIdentifier: "to-be-deleted.test-region.cratedb.net",
+				RecordTTL: endpoint.TTL(100),
+			},
+		},
+		UpdateOld: []*endpoint.Endpoint{
+			{
+				DNSName: "to-be-updated",
+				Targets: []string{"192.168.0.138", "192.168.1.138"},
+				RecordType: "A",
+				SetIdentifier: "to-be-updated.test-region.cratedb.net",
+				RecordTTL: endpoint.TTL(100),
+			},
+		},
+		UpdateNew: []*endpoint.Endpoint{
+			{
+				DNSName: "to-be-updated",
+				Targets: []string{"192.168.0.230", "192.168.1.231"},
+				RecordType: "A",
+				SetIdentifier: "to-be-updated.test-region.cratedb.net",
+				RecordTTL: endpoint.TTL(444),
+			},
+		},
+	}
+
+	client.On("Post", "/v1/regions/test-region/domains", &changes).Return("OK", nil).Once()
+
+	assert.NoError(provider.ApplyChanges(context.TODO(), &changes))
+
+	client.AssertExpectations(t)
+}


### PR DESCRIPTION
This provider delegates domain handling to a generic HTTP API.

It proxies the endpoint data structures to the API and expects 2 types of calls to be made to the API:
- GET. Where the Endpoints that represent the current state of the system are obtained from the third party.
- POST. Where the Changes structure that holds Create, Delete, UpdateOld and UpdateNew data is sent raw and expect the API to make the appropiate adjustments without having to know the details of the real external DNS.

It is based on the Godaddy provider implementation.

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
